### PR TITLE
Use *origin* for event origin in do-issue

### DIFF
--- a/event-loop.lisp
+++ b/event-loop.lisp
@@ -127,7 +127,7 @@
 
 (defmacro do-issue (event-type &rest args &key (loop '*standard-event-loop*) &allow-other-keys)
   (let ((args (removef args :loop)))
-    `(issue (make-instance ',event-type ,@args :origin (here)) ,loop)))
+    `(issue (make-instance ',event-type ,@args :origin (or *origin* (here))) ,loop)))
 
 (defun broadcast (event-type &rest args &key (loop *standard-event-loop*) &allow-other-keys)
   (let ((initargs (removef args :loop)))


### PR DESCRIPTION
Currently, `(with-origin ('foo) (do-issue deeds:info-event :message "test"))` will result in an event using `(here)` rather than `'foo` as the value for the origin slot.

This PR makes `do-issue` use `*origin*` for issued events if non-nil, and falls back to `(here)` otherwise.
